### PR TITLE
Update CTPicker.m

### DIFF
--- a/src/ios/CTPicker.m
+++ b/src/ios/CTPicker.m
@@ -23,7 +23,7 @@
 
 - (void) getPictures:(CDVInvokedUrlCommand *)command {
 	NSDictionary *options = [command.arguments objectAtIndex: 0];
-    [self.commandDelegate runInBackground:^{
+    
         NSInteger maxImages = [options[@"maxImages"] integerValue];
         NSInteger minImages = [options[@"minImages"] integerValue];
         self.width = [options[@"width"] integerValue] ?: 0;
@@ -58,7 +58,7 @@
         imagePicker.delegate = self;
         self.callbackId = command.callbackId;
         [self.viewController presentViewController:imagePicker animated:YES completion:NULL];
-    }];
+    
 }
 
 #pragma mark - QBImagePickerControllerDelegate


### PR DESCRIPTION
when runing in lastest ios 9.3.1 , that would be report an error      

Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'accessing _cachedSystemAnimationFence requires the main thread
